### PR TITLE
Update limit number of arguments to 3

### DIFF
--- a/scripts/timed_roslaunch.sh
+++ b/scripts/timed_roslaunch.sh
@@ -34,7 +34,7 @@ showHelp() {
     echo '</launch>'
 }
 
-if [ $# -lt 1 -o "$1" = "-h" ]; then
+if [ $# -lt 3 -o "$1" = "-h" ]; then
     showHelp
 else 
     echo "start wait for $1 seconds"


### PR DESCRIPTION
少なくとも、 [late time, package name, launch file name] の3つのステータスが必要。
なので、3つよりも引数が少なければエラーとする。

挙動を少々変更しました。