### PR TITLE
Add launch file for usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Make sure that the file is executable (chmod +x timed_roslaunch.sh)
 ### Run it from command line
 
 ```bash
-rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]"
+rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]
 ```
 
 Or
 
 ```bash
-roslaunch timed_roslaunch timed_roslaunch.launch time:=[number of second to delay] pkg:=[rospkg] file:=[roslaunch file] value:=[arguments (aptional)]
+roslaunch timed_roslaunch timed_roslaunch.launch time:=[number of second to delay] pkg:=[rospkg] file:=[roslaunch file] value:=[arguments (optional)]
 ```
 
 Example:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # timed_roslaunch
-refer to [Can I run a bash script using roslaunch?](http://answers.ros.org/question/51474/can-i-run-a-bash-script-using-roslaunch/)
-
 ## Usage
 This script can delay the launch of a roslaunch file.
 Make sure that the file is executable (chmod +x timed_roslaunch.sh)
@@ -8,13 +6,13 @@ Make sure that the file is executable (chmod +x timed_roslaunch.sh)
 ### Run it from command line
 
 ```bash
-./script/timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]
+rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]"
 ```
 
 Or
 
 ```bash
-rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]"
+roslaunch timed_roslaunch timed_roslaunch.launch time:=[number of second to delay] pkg:=[rospkg] file:=[roslaunch file] value:=[arguments (aptional)]
 ```
 
 Example:
@@ -24,6 +22,20 @@ rosrun timed_roslaunch timed_roslaunch.sh 2 turtlebot_navigation amcl_demo.launc
 ```
 
 ### Run it from another roslaunch file
+
+```xml
+<launch>
+  <include file="$(find timed_roslaunch)/launch/timed_roslaunch.launch">
+    <arg name="time" value="2" />
+    <arg name="pkg" value="turtlebot_navigation" />
+    <arg name="file" value="amcl_demo.launch" />
+    <arg name="value" value="initial_pose_x:=17.0 initial_pose_y:=17.0" />
+    <arg name="node_name" value="timed_roslaunch" /> <!-- This is optional argment -->
+  </include>
+</launch>
+```
+
+Or
 
 ```xml
 <launch>

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -1,0 +1,8 @@
+<launch>
+  <include file="$(find timed_roslaunch)/launch/timed_roslaunch.launch">
+    <arg name="time" value="2" />
+    <arg name="pkg" value="turtlebot_navigation" />
+    <arg name="file" value="amcl_demo.launch" />
+    <arg name="value" value="initial_pose_x:=17.0 initial_pose_y:=17.0" />
+  </include>
+</launch>

--- a/launch/timed_roslaunch.launch
+++ b/launch/timed_roslaunch.launch
@@ -1,0 +1,9 @@
+<launch>
+  <arg name="time" />
+  <arg name="pkg" />
+  <arg name="file" />
+  <arg name="value" default="" />
+  <arg name="node_name" default="timed_roslaunch_$(arg time)_$(arg pkg)" />
+
+  <node pkg="timed_roslaunch" type="timed_roslaunch.sh" args="$(arg time) $(arg pkg) $(arg file) $(arg value)" name="$(arg node_name)" />
+</launch>


### PR DESCRIPTION
引数の並びはわかりやすくて良いと思いますし、コマンドラインからは使いやすいですが、
launchファイルから呼び出すときどうしても見づらくなります。

そこで引数に名前をつけてlaunchファイル化しました。
使い方はexample.launchとREADME.mdに追加。

ユーザは自分のファイルを作るときexample.launchをコピって書き換えればよく、使い勝手もまずまずかと思います。
如何でしょうか。