### PR TITLE
make sure to handle spaces in parameters

### DIFF
--- a/scripts/timed_roslaunch.sh
+++ b/scripts/timed_roslaunch.sh
@@ -43,5 +43,5 @@ else
 
     shift # The sleep time is droped
         echo "now running 'roslaunch $@'"
-    roslaunch $@
+    roslaunch "$@"
 fi


### PR DESCRIPTION
`"$@"` is a special sequence expanded to a list of *quoted* arguments
Leaving this out might result in arguments split into multiple smaller arguments at this point