### PR TITLE
Added ROS time parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # timed_roslaunch [![Build Status](https://travis-ci.org/MoriKen254/timed_roslaunch.svg?branch)](https://travis-ci.org/MoriKen254/timed_roslaunch) 
 
-This script can delay the launch of a roslaunch file.
+This script can delay the launch of a roslaunch file.  Additionally ROS time can be used, allowing the delay to follow the ROS clock which may be slower than real-time, particularly in a simulation environment.
 
 ## Usage
 This script can delay the launch of a roslaunch file.
@@ -9,19 +9,19 @@ Make sure that the file is executable (chmod +x timed_roslaunch.sh)
 ### Run it from command line
 
 ```bash
-rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]
+rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [userostime (true or false)] [rospkg] [roslaunch file] [arguments (optional)]
 ```
 
 Or
 
 ```bash
-roslaunch timed_roslaunch timed_roslaunch.launch time:=[number of second to delay] pkg:=[rospkg] file:=[roslaunch file] value:=[arguments (optional)]
+roslaunch timed_roslaunch timed_roslaunch.launch time:=[number of second to delay] userostime:=[true or false] pkg:=[rospkg] file:=[roslaunch file] value:=[arguments (optional)]
 ```
 
 Example:
 
 ```bash
-rosrun timed_roslaunch timed_roslaunch.sh 2 turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=17.0"
+rosrun timed_roslaunch timed_roslaunch.sh 2 false turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=17.0"
 ```
 
 ### Run it from another roslaunch file
@@ -30,6 +30,7 @@ rosrun timed_roslaunch timed_roslaunch.sh 2 turtlebot_navigation amcl_demo.launc
 <launch>
   <include file="$(find timed_roslaunch)/launch/timed_roslaunch.launch">
     <arg name="time" value="2" />
+    <arg name="userostime" value="false" />
     <arg name="pkg" value="turtlebot_navigation" />
     <arg name="file" value="amcl_demo.launch" />
     <arg name="value" value="initial_pose_x:=17.0 initial_pose_y:=17.0" />
@@ -43,7 +44,7 @@ Or
 ```xml
 <launch>
   <node pkg="timed_roslaunch" type="timed_roslaunch.sh"
-    args="2 turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=17.0"
+    args="2 false turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=17.0"
     name="timed_roslaunch" output="screen" />
 </launch>
 ```

--- a/launch/timed_roslaunch.launch
+++ b/launch/timed_roslaunch.launch
@@ -1,9 +1,10 @@
 <launch>
   <arg name="time" default="0"/>
+  <arg name="userostime" default="false"/>
   <arg name="pkg" default=""/>
   <arg name="file" default=""/>
   <arg name="value" default="" />
   <arg name="node_name" default="timed_roslaunch_$(arg time)_$(arg pkg)" />
 
-  <node pkg="timed_roslaunch" type="timed_roslaunch.sh" args="$(arg time) $(arg pkg) $(arg file) $(arg value)" name="$(arg node_name)" />
+  <node pkg="timed_roslaunch" type="timed_roslaunch.sh" args="$(arg time) $(arg userostime) $(arg pkg) $(arg file) $(arg value)" name="$(arg node_name)"/>
 </launch>

--- a/scripts/timed_roslaunch.sh
+++ b/scripts/timed_roslaunch.sh
@@ -9,26 +9,27 @@
 # --------------------------------------------------------------------
 # Script to delay the launch of a roslaunch file
 #
-# Usage: sh timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file]
+# Usage: sh timed_roslaunch.sh [number of seconds to delay] [userostime] [rospkg] [roslaunch file]
 # --------------------------------------------------------------------
 
 showHelp() {
-    echo 
+    echo
     echo "This script can delay the launch of a roslaunch file"
     echo "Make sure that the file is executable (chmod +x timed_roslaunch.sh)"
-    echo 
+    echo "Use argument userostime=true when running on a slower simulator clock if desired"
+    echo
     echo "Run it from command line:"
-    echo 
-    echo "Usage: ./script/timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]"
-    echo "Or: rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [rospkg] [roslaunch file] [arguments (optional)]"
-    echo "Example: rosrun timed_roslaunch timed_roslaunch.sh 2 turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=17.0"
-    echo 
+    echo
+    echo "Usage: ./script/timed_roslaunch.sh [number of seconds to delay] [userostime (true or false)] [rospkg] [roslaunch file] [arguments (optional)]"
+    echo "Or: rosrun timed_roslaunch timed_roslaunch.sh [number of seconds to delay] [userostime (true or false)] [rospkg] [roslaunch file] [arguments (optional)]"
+    echo "Example: rosrun timed_roslaunch timed_roslaunch.sh 2 false turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=17.0"
+    echo
     echo "Or run it from another roslaunch file:"
-    echo 
+    echo
     echo '<launch>'
     echo '  <arg name="initial_pose_y" default="17.0" />'
     echo '  <node pkg="timed_launch" type="timed_roslaunch.sh"'
-    echo '    args="2 turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=$(arg initial_pose_y)"'
+    echo '    args="2 false turtlebot_navigation amcl_demo.launch initial_pose_x:=17.0 initial_pose_y:=$(arg initial_pose_y)"'
     echo '    name="timed_roslaunch" output="screen">'
     echo '  </node>'
     echo '</launch>'
@@ -36,12 +37,32 @@ showHelp() {
 
 if [ $# -lt 3 -o "$1" = "-h" ]; then
     showHelp
-else 
-    echo "start wait for $1 seconds"
-    sleep $1
-    echo "end wait for $1 seconds"
+else
+    if $2; then
+      echo "using ROS time"
+      IFS=''
+      # Get the clock time and use the separator to parse what we need
+      read -ra starttime <<< `rostopic echo -n1 /clock/clock/secs`
+      echo "start wait for $1 seconds"
+      # Sleep for the given time.  This assumes the sim time is slower than real time!
+      # But for long sleep times it doesn't make sense to do a check every single second
+      sleep $1
+      read -ra endtime <<< `rostopic echo -n1 /clock/clock/secs`
+      echo "start loop for $(($starttime + $1 - $endtime)) seconds"
+      # Every second check the new time until we've exceeded the request
+      while [ $endtime -le $(($starttime + $1)) ]; do
+        sleep 1
+        read -ra endtime <<< `rostopic echo -n1 /clock/clock/secs`
+      done
+      echo "end wait for $1 seconds"
+    else
+      echo "using wall time"
+      echo "start wait for $1 seconds"
+      sleep $1
+      echo "end wait for $1 seconds"
+    fi
 
-    shift # The sleep time is droped
+    shift 2 # The sleep time and userostime is droped
         echo "now running 'roslaunch $@'"
     roslaunch "$@"
 fi


### PR DESCRIPTION
Added a new parameter to allow use of ROS time.  This allows the delay to use the ROS clock instead of system clock, which is particularly useful in simulation environments where ROS time can be much slower than system time.  With this, nodes are able to be launched at exact ROS intervals without worrying about how quickly the system is running.