### PR TITLE
Add "output" option to launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ rosrun timed_roslaunch timed_roslaunch.sh 2 turtlebot_navigation amcl_demo.launc
     <arg name="pkg" value="turtlebot_navigation" />
     <arg name="file" value="amcl_demo.launch" />
     <arg name="value" value="initial_pose_x:=17.0 initial_pose_y:=17.0" />
-    <arg name="node_name" value="timed_roslaunch" /> <!-- This is optional jBrgment -->
+    <arg name="node_name" value="timed_roslaunch" /> <!-- This is an optional argument -->
+    <arg name="output" value="screen" /> <!-- This is an optional argument -->
   </include>
 </launch>
 ```

--- a/launch/timed_roslaunch.launch
+++ b/launch/timed_roslaunch.launch
@@ -4,6 +4,7 @@
   <arg name="file" default=""/>
   <arg name="value" default="" />
   <arg name="node_name" default="timed_roslaunch_$(arg time)_$(arg pkg)" />
+  <arg name="output" default="log" />
 
-  <node pkg="timed_roslaunch" type="timed_roslaunch.sh" args="$(arg time) $(arg pkg) $(arg file) $(arg value)" name="$(arg node_name)" />
+  <node pkg="timed_roslaunch" type="timed_roslaunch.sh" args="$(arg time) $(arg pkg) $(arg file) $(arg value)" name="$(arg node_name)" output="$(arg output)" />
 </launch>


### PR DESCRIPTION
This PR adds and "output" option to `timed_roslaunch.launch`.